### PR TITLE
feat: enable bluetooth upon probing

### DIFF
--- a/bes2600/bes2600_sdio.c
+++ b/bes2600/bes2600_sdio.c
@@ -1878,6 +1878,7 @@ static int bes2600_sdio_probe(struct sdio_func *func,
 
 out:
 	bes2600_chrdev_set_sbus_priv_data(self, false);
+	bes2600_switch_bt(true);
 	bes2600_gpio_allow_mcu_sleep(self, GPIO_WAKE_FLAG_SDIO_PROBE);
 	return 0;
 

--- a/bes2600/bes_chardev.c
+++ b/bes2600/bes_chardev.c
@@ -196,7 +196,7 @@ static int bes2600_switch_wifi(bool on)
 	return ret;
 }
 
-static int bes2600_switch_bt(bool on)
+int bes2600_switch_bt(bool on)
 {
 	int ret = 0;
 	long status = 0;
@@ -229,11 +229,11 @@ static int bes2600_switch_bt(bool on)
 			/* check if there is a error when bootup */
 			ret = (status <= 0 || bes2600_chrdev_is_bus_error()) ? -1 : 0;
 		} else {
-			bes_devel("bes2600 activate bt.\n");
+			bes_info("enable BT\n");
 			ret = bes2600_chrdev_switch_subsys(GPIO_WAKE_FLAG_BT_ON, SUBSYSTEM_BT, true);
 		}
 	} else {
-		bes_devel("bes2600 deactivate bt.\n");
+		bes_info("disable BT\n");
 		bes2600_chrdev_switch_subsys(GPIO_WAKE_FLAG_BT_OFF, SUBSYSTEM_BT, false);
 	}
 

--- a/bes2600/bes_chardev.h
+++ b/bes2600/bes_chardev.h
@@ -91,4 +91,6 @@ u8* bes2600_alloc_dpd_log_buffer(u16 len);
 void bes2600_get_dpd_log(char **data, size_t *len);
 #endif
 
+int bes2600_switch_bt(bool);
+
 #endif /* __BES_CHARDEV_H__ */


### PR DESCRIPTION
This PR is a tweak to enable Bluetooth automatically upon module probing to avoid using /dev/bes2600 chardev for that.